### PR TITLE
[JS] Add support for cursor pagination to JS clients

### DIFF
--- a/javascript/lib/api/src/model/response.ts
+++ b/javascript/lib/api/src/model/response.ts
@@ -107,7 +107,7 @@ export class SearchThingsResponse extends EntityModel {
       return o;
     }
     // @ts-ignore
-    return new SearchThingsResponse(o['items'].map((t: object) => Thing.fromObject(t)), o['nextPageOffset']);
+    return new SearchThingsResponse(o['items'].map((t: object) => Thing.fromObject(t)), o['nextPageOffset'], o['cursor']);
   }
 
   public toObject(): object {

--- a/javascript/lib/api/src/options/request.options.ts
+++ b/javascript/lib/api/src/options/request.options.ts
@@ -267,11 +267,12 @@ export class DefaultCountOptions extends AbstractRequestOptions<DefaultCountOpti
  */
 export interface SearchOptions extends AddRequestOptions<SearchOptions>, HasFilterAndNamespace<SearchOptions>, HasFields<SearchOptions> {
   /**
-   * Sets a limit option.
-   *
    * @param offset - The index to start at.
    * @param count - The number of things to return.
    * @returns The instance of SearchOptions with the added option
+   *
+   * @Deprecated See {@link https://www.eclipse.org/ditto/basic-search.html#rql-paging-deprecated} Use cursor pagination instead
+   * Sets a limit option.
    */
   withLimit(offset: number, count: number): SearchOptions;
 
@@ -283,18 +284,34 @@ export interface SearchOptions extends AddRequestOptions<SearchOptions>, HasFilt
    */
   withSort(sortOperation: string): SearchOptions;
 
+  /**
+   * Sets a cursor option
+   *
+   * @param cursor - The cursor to use for pagination, returned by a previous search request
+   */
+  withCursor(cursor: string): SearchOptions;
+
+  /**
+   * Sets the page size for pagination.
+   * Only works with cursor pagination.
+   * Maximum page size supported by ditto is 200.
+   * @param pageSize Number of items to return per page
+   */
+  withPageSize(pageSize: number): SearchOptions;
 }
 
 
 export class DefaultSearchOptions extends AbstractRequestOptions<DefaultSearchOptions>
   implements SearchOptions {
-  private sort: string;
-  private limit: string;
+
+  /**
+   * Map of name-value pairs to add to the request parameters as "option"
+   */
+  private optionParameters: Map<string, string> = new Map();
 
   private constructor() {
     super();
-    this.sort = '';
-    this.limit = '';
+
   }
 
   /**
@@ -327,12 +344,22 @@ export class DefaultSearchOptions extends AbstractRequestOptions<DefaultSearchOp
   }
 
   public withLimit(offset: number, count: number): DefaultSearchOptions {
-    this.limit = `limit(${offset},${count})`;
+    this.optionParameters.set('limit', `${offset},${count}`);
     return this.setOption();
   }
 
   public withSort(sortOperation: string): DefaultSearchOptions {
-    this.sort = `sort(${sortOperation})`;
+    this.optionParameters.set(`sort`, sortOperation);
+    return this.setOption();
+  }
+
+  public withCursor(cursor: string): DefaultCountOptions {
+    this.optionParameters.set(`cursor`, cursor);
+    return this.setOption();
+  }
+
+  public withPageSize(pageSize: number): DefaultSearchOptions {
+    this.optionParameters.set('size', pageSize.toFixed(0));
     return this.setOption();
   }
 
@@ -342,14 +369,11 @@ export class DefaultSearchOptions extends AbstractRequestOptions<DefaultSearchOp
    * @returns The instance of DefaultSearchOptions with the constructed option
    */
   private setOption(): DefaultSearchOptions {
-    let parameter: string;
-    if (this.sort === '') {
-      parameter = this.limit;
-    } else if (this.limit === '') {
-      parameter = this.sort;
-    } else {
-      parameter = `${this.limit},${this.sort}`;
-    }
+
+    const parameter = Array.from(this.optionParameters.entries())
+      .map(([key, value]) => `${key}(${value})`)
+      .join(',');
+
     this.addRequestParameter('option', encodeURIComponent(parameter));
     return this;
   }

--- a/javascript/lib/api/src/options/request.options.ts
+++ b/javascript/lib/api/src/options/request.options.ts
@@ -148,7 +148,8 @@ export interface HasFilterAndNamespace<T extends HasFilterAndNamespace<T>> {
 
 export interface RequestOptionsWithMatchOptions<T extends RequestOptionsWithMatchOptions<T>>
   extends AddRequestOptions<RequestOptionsWithMatchOptions<T>>,
-  HasMatch<RequestOptionsWithMatchOptions<T>> { }
+    HasMatch<RequestOptionsWithMatchOptions<T>> {
+}
 
 
 export abstract class AbstractRequestOptionsWithMatchOptions<T extends AbstractRequestOptionsWithMatchOptions<T>>
@@ -178,7 +179,8 @@ export abstract class AbstractRequestOptionsWithMatchOptions<T extends AbstractR
 /**
  * Option provider for If-Match / If-None-Match headers
  */
-export interface MatchOptions extends RequestOptionsWithMatchOptions<MatchOptions> {}
+export interface MatchOptions extends RequestOptionsWithMatchOptions<MatchOptions> {
+}
 
 export class DefaultMatchOptions extends AbstractRequestOptionsWithMatchOptions<DefaultMatchOptions> implements MatchOptions {
 
@@ -344,6 +346,9 @@ export class DefaultSearchOptions extends AbstractRequestOptions<DefaultSearchOp
   }
 
   public withLimit(offset: number, count: number): DefaultSearchOptions {
+    if (this.optionParameters.has('cursor') || this.optionParameters.has('size')) {
+      throw new Error('Cursor/size and limit options cannot be set at the same time');
+    }
     this.optionParameters.set('limit', `${offset},${count}`);
     return this.setOption();
   }
@@ -354,11 +359,17 @@ export class DefaultSearchOptions extends AbstractRequestOptions<DefaultSearchOp
   }
 
   public withCursor(cursor: string): DefaultSearchOptions {
+    if (this.optionParameters.has('limit')) {
+      throw new Error('Limit and cursor options cannot be set at the same time');
+    }
     this.optionParameters.set(`cursor`, cursor);
     return this.setOption();
   }
 
   public withPageSize(pageSize: number): DefaultSearchOptions {
+    if (this.optionParameters.has('limit')) {
+      throw new Error('Limit and cursor options cannot be set at the same time');
+    }
     this.optionParameters.set('size', pageSize.toFixed(0));
     return this.setOption();
   }

--- a/javascript/lib/api/src/options/request.options.ts
+++ b/javascript/lib/api/src/options/request.options.ts
@@ -353,7 +353,7 @@ export class DefaultSearchOptions extends AbstractRequestOptions<DefaultSearchOp
     return this.setOption();
   }
 
-  public withCursor(cursor: string): DefaultCountOptions {
+  public withCursor(cursor: string): DefaultSearchOptions {
     this.optionParameters.set(`cursor`, cursor);
     return this.setOption();
   }

--- a/javascript/lib/api/tests/options/request.options.spec.ts
+++ b/javascript/lib/api/tests/options/request.options.spec.ts
@@ -212,6 +212,24 @@ describe('Search Options', () => {
     searchOptions.withLimit(3, 4).withSort('-B');
     expect(searchOptions.getOptions().get('option')).toEqual(encodeURIComponent('limit(3,4),sort(-B)'));
   });
+  it('sets cursor', () => {
+    searchOptions.withCursor('eJylkD1PwzAQhv-LpxQc5YM0SbNBBBJDp0oslMGxz82JYJfLBQbEf8cpQupGKfZ29zz3Su');
+    expect(searchOptions.getOptions().get('option')).toEqual('cursor(eJylkD1PwzAQhv-LpxQc5YM0SbNBBBJDp0oslMGxz82JYJfLBQbEf8cpQupGKfZ29zz3Su)');
+  });
+  it('overrides cursor', () => {
+    searchOptions.withCursor('foo');
+    searchOptions.withCursor('bar');
+    expect(searchOptions.getOptions().get('option')).toEqual('cursor(bar)');
+  });
+  it('sets page size', () => {
+    searchOptions.withPageSize(42);
+    expect(searchOptions.getOptions().get('option')).toEqual('size(42)');
+  });
+  it('overrides page size', () => {
+    searchOptions.withPageSize(42);
+    searchOptions.withPageSize(10);
+    expect(searchOptions.getOptions().get('option')).toEqual('size(10)');
+  });
 });
 
 describe('Get Things Options', () => {

--- a/javascript/lib/api/tests/options/request.options.spec.ts
+++ b/javascript/lib/api/tests/options/request.options.spec.ts
@@ -234,6 +234,19 @@ describe('Search Options', () => {
     searchOptions.withCursor('eJylkD1PwzAQhv-LpxQc5YM0SbNBBBJDp0oslMGxz82JYJfLBQbEf8cpQupGKfZ29zz3Su').withPageSize(42);
     expect(searchOptions.getOptions().get('option')).toEqual(encodeURIComponent('cursor(eJylkD1PwzAQhv-LpxQc5YM0SbNBBBJDp0oslMGxz82JYJfLBQbEf8cpQupGKfZ29zz3Su),size(42)'));
   });
+  it('throws an error when setting limit and cursor is already set', () => {
+    searchOptions.withCursor('foo');
+    expect(() => searchOptions.withLimit(10, 10)).toThrowError();
+  });
+  it('throws an error when setting pageSize and limit is already set', () => {
+    searchOptions.withLimit(10, 10);
+    expect(() => searchOptions.withPageSize(10)).toThrowError();
+  });
+  it('throws an error when setting cursor and limit is already set', () => {
+    searchOptions.withLimit(10, 10);
+    expect(() => searchOptions.withCursor('foo')).toThrowError();
+  });
+
 });
 
 describe('Get Things Options', () => {

--- a/javascript/lib/api/tests/options/request.options.spec.ts
+++ b/javascript/lib/api/tests/options/request.options.spec.ts
@@ -230,6 +230,10 @@ describe('Search Options', () => {
     searchOptions.withPageSize(10);
     expect(searchOptions.getOptions().get('option')).toEqual('size(10)');
   });
+  it('sets cursor and size', () => {
+    searchOptions.withCursor('eJylkD1PwzAQhv-LpxQc5YM0SbNBBBJDp0oslMGxz82JYJfLBQbEf8cpQupGKfZ29zz3Su').withPageSize(42);
+    expect(searchOptions.getOptions().get('option')).toEqual(encodeURIComponent('cursor(eJylkD1PwzAQhv-LpxQc5YM0SbNBBBJDp0oslMGxz82JYJfLBQbEf8cpQupGKfZ29zz3Su),size(42)'));
+  });
 });
 
 describe('Get Things Options', () => {


### PR DESCRIPTION
As per the documentation (https://www.eclipse.org/ditto/basic-search.html#rql-paging-deprecated), pagination via the `limit` parameter is deprecated and might get removed in the future.
This PR adds support for cursor pagination to the JS client so applications using the client can use the new pagination style