### PR TITLE
re-check reconnecting state before emitting

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -372,10 +372,15 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
                         LOGGER.debug("Reconnecting is completed -> emitting subscriptionMessages: {}", subscriptionMessages);
                         subscriptionMessages.values().forEach(this::emit);
                     }
-                } catch (TimeoutException | InterruptedException | ExecutionException e) {
+                } catch (TimeoutException | ExecutionException e) {
                     isReconnecting.complete(false);
                     fixedRateChecker.cancel(true);
                     LOGGER.error("Reconnecting failed: {}", e.getMessage());
+                } catch (InterruptedException e) {
+                    isReconnecting.complete(false);
+                    fixedRateChecker.cancel(true);
+                    LOGGER.error("Reconnecting failed due to thread being interrupted: {}", e.getMessage());
+                    Thread.currentThread().interrupt();
                 }
             }
         });


### PR DESCRIPTION
 - since the connectExecutor thread starts a reconnect which in turn causes the websocket connection to go into onConnected() method in the default(callback). This can cause an emit of message before reconnecting boolean is set to false
 - introduced a mechanism in order to make sure and retry several times to get the correct value

Fixes: #231 