### PR TITLE
Enable TLS certificate validation for Node WebSocket transport (CWE-295)

### DIFF
--- a/javascript/lib/node/README.md
+++ b/javascript/lib/node/README.md
@@ -61,3 +61,32 @@ DittoNodeClient.newHttpClient(proxyOptions)
 //  ...
 ```
 Any options that are set manually will override options that are read from an environment variable.
+
+
+### TLS
+
+For `wss://` (and `https://`) connections the server certificate is validated against the
+system's trusted certificate authorities and the requested hostname, using Node.js' secure
+defaults. No configuration is required for the common case.
+
+If the server presents a certificate that is not part of the system trust store (e.g. a
+corporate root CA or a self-signed certificate), the trusted certificate(s) can be supplied
+via the optional `tlsOptions` parameter of `newWebSocketClient(...)`:
+
+```javascript
+const fs = require('fs');
+
+const tlsOptions = {
+  ca: fs.readFileSync('corp-root.pem')
+};
+
+DittoNodeClient.newWebSocketClient(undefined, tlsOptions)
+//  ...
+```
+
+`tlsOptions` also accepts `cert` / `key` / `passphrase` / `pfx` for mutual TLS.
+
+> **Warning:** certificate validation can be disabled explicitly with
+> `{ rejectUnauthorized: false }`. This exposes the connection to man-in-the-middle attacks
+> and must only be used for local development against a self-signed certificate — never in
+> production.

--- a/javascript/lib/node/src/ditto-node-client.ts
+++ b/javascript/lib/node/src/ditto-node-client.ts
@@ -16,6 +16,7 @@ import { WebSocketBuilderInitialStep, WebSocketClientBuilder } from '../../api/s
 import { NodeRequester } from './node-http';
 import { NodeWebSocketBuilder } from './node-websocket';
 import { ProxyAgent, ProxyOptions } from './proxy-settings';
+import { TlsOptions } from './tls-settings';
 
 /**
  * Starting point to build clients that can be used to get handles for NodeJS.
@@ -38,9 +39,11 @@ export class DittoNodeClient {
    * The returned builder utilizes *Object scoping* to guide you through the building process.
    *
    * @param proxyOptions - Options to establish a proxy connection.
+   * @param tlsOptions - Options to configure TLS for {@code wss://} connections (e.g. custom trusted CAs).
+   *  When omitted, NodeJS' secure defaults are used and the server certificate is validated.
    * @return the builder.
    */
-  public static newWebSocketClient(proxyOptions?: ProxyOptions): WebSocketBuilderInitialStep {
-    return WebSocketClientBuilder.newBuilder(new NodeWebSocketBuilder(new ProxyAgent(proxyOptions)));
+  public static newWebSocketClient(proxyOptions?: ProxyOptions, tlsOptions?: TlsOptions): WebSocketBuilderInitialStep {
+    return WebSocketClientBuilder.newBuilder(new NodeWebSocketBuilder(new ProxyAgent(proxyOptions), tlsOptions));
   }
 }

--- a/javascript/lib/node/src/node-websocket.ts
+++ b/javascript/lib/node/src/node-websocket.ts
@@ -115,8 +115,19 @@ export class NodeWebSocket implements WebSocketImplementation {
   private reconnect(retry: number): Promise<WebSocketImplementation> {
     if (this.shouldReconnect) {
       return new Promise<WebSocketImplementation>((resolve, reject) => {
-        this.webSocket = new WebSocket(this.webSocketUrl, this.options);
-        this.webSocket.on('open', () => {
+        const webSocket = new WebSocket(this.webSocketUrl, this.options);
+        this.webSocket = webSocket;
+        // NodeJS escalates an 'error' event on an emitter without an 'error' listener to an
+        // uncaught exception, which by default terminates the host process. setHandles() only
+        // installs its listeners once the connection is open, so a reconnect attempt that fails
+        // during the handshake (e.g. because of a rotated or expired certificate) needs its own
+        // listener here. The retry ladder below keeps its backoff and drives the next attempt.
+        const handleConnectError = (error: Error) => {
+          this.handler.handleError(error.toString());
+        };
+        webSocket.on('error', handleConnectError);
+        webSocket.on('open', () => {
+          webSocket.removeListener('error', handleConnectError);
           this.connected = true;
           this.setHandles();
           resolve(this);
@@ -128,6 +139,7 @@ export class NodeWebSocket implements WebSocketImplementation {
           if (retry <= 120000) {
             console.log('Reconnect failed! Trying again!');
             resolve(this.reconnect(retry * 2));
+            return;
           }
           console.log('Reconnect failed!');
           reject('Reconnect failed: Timed out');

--- a/javascript/lib/node/src/node-websocket.ts
+++ b/javascript/lib/node/src/node-websocket.ts
@@ -23,6 +23,7 @@ import {
   DittoURL
 } from '../../api/src/auth/auth-provider';
 import { ProxyAgent } from './proxy-settings';
+import { TlsOptions } from './tls-settings';
 import * as WebSocket from 'ws';
 import * as http from 'http';
 
@@ -61,16 +62,18 @@ export class NodeWebSocket implements WebSocketImplementation {
    * @param authProviders - The auth providers to use.
    * @param agent - The proxy agent to use to establish the connection.
    * @param reconnect - Whether to automatically reconnect on connection loss.
+   * @param tlsOptions - Optional TLS options for {@code wss://} connections (e.g. custom trusted CAs).
    * @return a Promise for the web socket connection.
    */
   public static buildInstance(url: DittoURL, handler: ResponseHandler,
-                              authProviders: AuthProvider[], agent: ProxyAgent, reconnect: boolean = true): Promise<NodeWebSocket> {
-    return new Promise<NodeWebSocket>(resolve => {
+                              authProviders: AuthProvider[], agent: ProxyAgent, reconnect: boolean = true,
+                              tlsOptions?: TlsOptions): Promise<NodeWebSocket> {
+    return new Promise<NodeWebSocket>((resolve, reject) => {
       const [authenticatedUrl, authenticatedHeaders] = authenticateWithUrlAndHeaders(url, new Map(), authProviders);
       const plainHeaders = mapToPlainObject(authenticatedHeaders);
       const options: WebSocket.ClientOptions = {
+        ...tlsOptions,
         agent: NodeWebSocket.getProxyAgentForProtocol(url, agent),
-        rejectUnauthorized: false,
         headers: plainHeaders
       };
 
@@ -78,6 +81,9 @@ export class NodeWebSocket implements WebSocketImplementation {
       const webSocket = new WebSocket(plainUrl, options);
       webSocket.on('open', () => {
         resolve(new NodeWebSocket(webSocket, plainUrl, handler, options, reconnect));
+      });
+      webSocket.once('error', error => {
+        reject(error);
       });
     });
   }
@@ -156,11 +162,11 @@ export class NodeWebSocketBuilder implements WebSocketImplementationBuilderUrl, 
   private authProviders!: AuthProvider[];
   private dittoUrl!: DittoURL;
 
-  public constructor(private readonly agent: ProxyAgent) {
+  public constructor(private readonly agent: ProxyAgent, private readonly tlsOptions?: TlsOptions) {
   }
 
   public withHandler(handler: ResponseHandler, reconnect: boolean = true): Promise<NodeWebSocket> {
-    return NodeWebSocket.buildInstance(this.dittoUrl, handler, this.authProviders, this.agent, reconnect);
+    return NodeWebSocket.buildInstance(this.dittoUrl, handler, this.authProviders, this.agent, reconnect, this.tlsOptions);
   }
 
   withConnectionDetails(url: DittoURL, authProviders: AuthProvider[]): WebSocketImplementationBuilderHandler {

--- a/javascript/lib/node/src/tls-settings.ts
+++ b/javascript/lib/node/src/tls-settings.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Options to configure TLS for the NodeJS transports (e.g. {@code wss://} connections).
+ *
+ * By default (i.e. when no {@link TlsOptions} are provided) the client relies on NodeJS'
+ * secure defaults: the server certificate is validated against the well-known certificate
+ * authorities and the requested hostname. Use these options to supply additional trust
+ * material (e.g. a corporate root CA) or a client certificate for mutual TLS.
+ */
+export interface TlsOptions {
+  /**
+   * Optionally overrides the trusted CA certificates. Provide one or more PEM encoded
+   * certificates to trust, e.g. a self-signed or corporate root certificate that is not
+   * part of the system trust store.
+   */
+  ca?: string | Buffer | Array<string | Buffer>;
+  /** Optional client certificate chain (PEM) to present for mutual TLS. */
+  cert?: string | Buffer | Array<string | Buffer>;
+  /** Optional private key (PEM) belonging to {@link cert} for mutual TLS. */
+  key?: string | Buffer | Array<string | Buffer>;
+  /** Optional passphrase for the private key. */
+  passphrase?: string;
+  /** Optional PKCS#12 encoded private key and certificate chain for mutual TLS. */
+  pfx?: string | Buffer | Array<string | Buffer>;
+  /**
+   * Whether to reject connections whose server certificate cannot be validated (invalid
+   * chain, expired, or hostname mismatch).
+   *
+   * Defaults to {@code true} (secure). Setting this to {@code false} disables certificate
+   * validation and exposes the connection to man-in-the-middle attacks; only use it for an
+   * explicit, audited opt-out (e.g. local development against a self-signed certificate).
+   */
+  rejectUnauthorized?: boolean;
+}

--- a/javascript/lib/node/tests/node-websocket.spec.ts
+++ b/javascript/lib/node/tests/node-websocket.spec.ts
@@ -1,0 +1,104 @@
+/*!
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import * as https from 'https';
+import * as crypto from 'crypto';
+import { execFileSync } from 'child_process';
+import { AddressInfo, Socket } from 'net';
+import { ImmutableURL } from '../../api/src/auth/auth-provider';
+import { NodeWebSocketBasicAuth } from '../src/node-auth';
+import { NodeWebSocket } from '../src/node-websocket';
+import { ProxyAgent } from '../src/proxy-settings';
+
+/**
+ * Regression tests for the TLS certificate validation of the NodeJS WebSocket transport.
+ *
+ * Historically {@code NodeWebSocket.buildInstance} hard-coded {@code rejectUnauthorized: false},
+ * which silently disabled certificate validation for every {@code wss://} connection and allowed
+ * man-in-the-middle attackers to intercept credentials (CWE-295). These tests verify that the
+ * secure NodeJS default is used and that an explicit, per-client opt-out remains possible.
+ */
+describe('NodeWebSocket TLS certificate validation', () => {
+
+  let server: https.Server;
+  let port: number;
+  let capturedAuthorization: string | undefined;
+  const upgradedSockets: Socket[] = [];
+
+  const noopHandler: any = {
+    handleInput: () => { /* noop */ },
+    handleResponse: () => { /* noop */ },
+    handleMessage: () => { /* noop */ },
+    handleClose: (promise: Promise<unknown>) => { promise.catch(() => { /* reconnect disabled in test */ }); },
+    handleFailure: () => { /* noop */ },
+    handleError: () => { /* noop */ }
+  };
+
+  const buildWss = (rejectUnauthorized?: boolean) => {
+    const url = ImmutableURL.newInstance('wss', `127.0.0.1:${port}`, '/ws/2');
+    const authProvider = NodeWebSocketBasicAuth.newInstance('victim-user', 'victim-pass');
+    const tlsOptions = rejectUnauthorized === undefined ? undefined : { rejectUnauthorized };
+    return NodeWebSocket.buildInstance(url, noopHandler, [authProvider], new ProxyAgent(), false, tlsOptions);
+  };
+
+  beforeAll(done => {
+    // Self-signed certificate for a non-matching hostname (CN=evil.example) so both the chain
+    // and the hostname check fail. Generated with openssl to avoid an extra runtime dependency.
+    const pems = execFileSync('openssl', [
+      'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-keyout', '-', '-days', '1',
+      '-subj', '/CN=evil.example'
+    ]).toString();
+    const key = pems.substring(pems.indexOf('-----BEGIN PRIVATE KEY-----'), pems.indexOf('-----END PRIVATE KEY-----') + '-----END PRIVATE KEY-----'.length);
+    const cert = pems.substring(pems.indexOf('-----BEGIN CERTIFICATE-----'));
+
+    server = https.createServer({ key, cert });
+    server.on('upgrade', (req, socket) => {
+      upgradedSockets.push(socket);
+      capturedAuthorization = req.headers['authorization'];
+      const accept = crypto.createHash('sha1')
+        .update(req.headers['sec-websocket-key'] + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+        .digest('base64');
+      socket.write(
+        'HTTP/1.1 101 Switching Protocols\r\n' +
+        'Upgrade: websocket\r\n' +
+        'Connection: Upgrade\r\n' +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+      );
+    });
+    server.listen(0, '127.0.0.1', () => {
+      port = (server.address() as AddressInfo).port;
+      done();
+    });
+  });
+
+  afterAll(done => {
+    upgradedSockets.forEach(socket => socket.destroy());
+    server.close(() => done());
+  });
+
+  beforeEach(() => {
+    capturedAuthorization = undefined;
+  });
+
+  it('rejects an untrusted (self-signed, hostname-mismatched) certificate by default', async () => {
+    await expect(buildWss()).rejects.toBeDefined();
+    expect(capturedAuthorization).toBeUndefined();
+  });
+
+  it('allows an explicit, per-client opt-out via { rejectUnauthorized: false }', async () => {
+    const webSocket = await buildWss(false);
+    expect(webSocket).toBeTruthy();
+    expect(capturedAuthorization).toBeDefined();
+    webSocket.close();
+  });
+});

--- a/javascript/lib/node/tests/node-websocket.spec.ts
+++ b/javascript/lib/node/tests/node-websocket.spec.ts
@@ -15,10 +15,50 @@ import * as https from 'https';
 import * as crypto from 'crypto';
 import { execFileSync } from 'child_process';
 import { AddressInfo, Socket } from 'net';
+import { IncomingMessage } from 'http';
 import { ImmutableURL } from '../../api/src/auth/auth-provider';
 import { NodeWebSocketBasicAuth } from '../src/node-auth';
 import { NodeWebSocket } from '../src/node-websocket';
 import { ProxyAgent } from '../src/proxy-settings';
+
+/**
+ * Self-signed certificate for a non-matching hostname (CN=evil.example) so that both the chain and
+ * the hostname check fail. Generated with openssl to avoid an extra runtime dependency.
+ */
+const selfSigned = (() => {
+  const pems = execFileSync('openssl', [
+    'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-keyout', '-', '-days', '1',
+    '-subj', '/CN=evil.example'
+  ]).toString();
+  const key = pems.substring(pems.indexOf('-----BEGIN PRIVATE KEY-----'), pems.indexOf('-----END PRIVATE KEY-----') + '-----END PRIVATE KEY-----'.length);
+  const cert = pems.substring(pems.indexOf('-----BEGIN CERTIFICATE-----'));
+  return { key, cert };
+})();
+
+/**
+ * Completes a WebSocket upgrade with a bare {@code 101} handshake response, which is all the
+ * {@code ws} client needs to consider itself connected.
+ */
+const acceptUpgrade = (req: IncomingMessage, socket: Socket): void => {
+  const accept = crypto.createHash('sha1')
+    .update(req.headers['sec-websocket-key'] + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+    .digest('base64');
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+    'Upgrade: websocket\r\n' +
+    'Connection: Upgrade\r\n' +
+    `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+  );
+};
+
+const noopHandler: any = {
+  handleInput: () => { /* noop */ },
+  handleResponse: () => { /* noop */ },
+  handleMessage: () => { /* noop */ },
+  handleClose: (promise: Promise<unknown>) => { promise.catch(() => { /* reconnect disabled in test */ }); },
+  handleFailure: () => { /* noop */ },
+  handleError: () => { /* noop */ }
+};
 
 /**
  * Regression tests for the TLS certificate validation of the NodeJS WebSocket transport.
@@ -35,15 +75,6 @@ describe('NodeWebSocket TLS certificate validation', () => {
   let capturedAuthorization: string | undefined;
   const upgradedSockets: Socket[] = [];
 
-  const noopHandler: any = {
-    handleInput: () => { /* noop */ },
-    handleResponse: () => { /* noop */ },
-    handleMessage: () => { /* noop */ },
-    handleClose: (promise: Promise<unknown>) => { promise.catch(() => { /* reconnect disabled in test */ }); },
-    handleFailure: () => { /* noop */ },
-    handleError: () => { /* noop */ }
-  };
-
   const buildWss = (rejectUnauthorized?: boolean) => {
     const url = ImmutableURL.newInstance('wss', `127.0.0.1:${port}`, '/ws/2');
     const authProvider = NodeWebSocketBasicAuth.newInstance('victim-user', 'victim-pass');
@@ -52,28 +83,11 @@ describe('NodeWebSocket TLS certificate validation', () => {
   };
 
   beforeAll(done => {
-    // Self-signed certificate for a non-matching hostname (CN=evil.example) so both the chain
-    // and the hostname check fail. Generated with openssl to avoid an extra runtime dependency.
-    const pems = execFileSync('openssl', [
-      'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-keyout', '-', '-days', '1',
-      '-subj', '/CN=evil.example'
-    ]).toString();
-    const key = pems.substring(pems.indexOf('-----BEGIN PRIVATE KEY-----'), pems.indexOf('-----END PRIVATE KEY-----') + '-----END PRIVATE KEY-----'.length);
-    const cert = pems.substring(pems.indexOf('-----BEGIN CERTIFICATE-----'));
-
-    server = https.createServer({ key, cert });
+    server = https.createServer(selfSigned);
     server.on('upgrade', (req, socket) => {
       upgradedSockets.push(socket);
       capturedAuthorization = req.headers['authorization'];
-      const accept = crypto.createHash('sha1')
-        .update(req.headers['sec-websocket-key'] + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
-        .digest('base64');
-      socket.write(
-        'HTTP/1.1 101 Switching Protocols\r\n' +
-        'Upgrade: websocket\r\n' +
-        'Connection: Upgrade\r\n' +
-        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
-      );
+      acceptUpgrade(req, socket);
     });
     server.listen(0, '127.0.0.1', () => {
       port = (server.address() as AddressInfo).port;
@@ -100,5 +114,77 @@ describe('NodeWebSocket TLS certificate validation', () => {
     expect(webSocket).toBeTruthy();
     expect(capturedAuthorization).toBeDefined();
     webSocket.close();
+  });
+});
+
+/**
+ * Regression test for the error handling of {@code NodeWebSocket.reconnect}.
+ *
+ * The reconnect attempt installs its message/close/error handlers only once the fresh connection is
+ * open. A handshake failure before that point - which certificate validation makes a realistic
+ * scenario, e.g. after a certificate rotation - used to be emitted on a {@code WebSocket} without
+ * any 'error' listener, which NodeJS escalates to an uncaught exception that terminates the host
+ * process.
+ */
+describe('NodeWebSocket reconnect', () => {
+
+  let server: https.Server;
+  let port: number;
+  let upgradedSocket: Socket;
+
+  beforeEach(done => {
+    server = https.createServer(selfSigned);
+    server.on('upgrade', (req, socket) => {
+      upgradedSocket = socket;
+      acceptUpgrade(req, socket);
+    });
+    server.listen(0, '127.0.0.1', () => {
+      port = (server.address() as AddressInfo).port;
+      done();
+    });
+  });
+
+  it('reports a failed reconnect attempt instead of escalating it to an uncaught exception', async () => {
+    let closed = false;
+    let reconnectError: string | undefined;
+    let reportReconnectError: () => void;
+    const reconnectErrorReported = new Promise<void>(resolve => {
+      reportReconnectError = resolve;
+    });
+    let reconnectSettled: Promise<unknown> = Promise.resolve();
+    const handler: any = {
+      ...noopHandler,
+      handleClose: (promise: Promise<unknown>) => {
+        closed = true;
+        // the retry ladder eventually gives up; keep the rejection from becoming an unhandled one
+        reconnectSettled = promise.catch(() => { /* expected: the server is gone */ });
+      },
+      handleError: (error: string) => {
+        // errors reported after the close event originate from the reconnect attempt
+        if (closed && reconnectError === undefined) {
+          reconnectError = error;
+          reportReconnectError();
+        }
+      }
+    };
+
+    const url = ImmutableURL.newInstance('wss', `127.0.0.1:${port}`, '/ws/2');
+    const authProvider = NodeWebSocketBasicAuth.newInstance('user', 'pass');
+    const webSocket = await NodeWebSocket.buildInstance(url, handler, [authProvider], new ProxyAgent(),
+      true, { rejectUnauthorized: false });
+
+    // stop listening first, so that the reconnect attempt triggered by the close below cannot succeed
+    await new Promise<void>(resolve => {
+      server.close(() => resolve());
+      upgradedSocket.end();
+    });
+
+    await reconnectErrorReported;
+    expect(reconnectError).toContain('ECONNREFUSED');
+
+    // disable further attempts and let the pending retry ladder settle, so that no timer of it
+    // outlives the test
+    webSocket.close();
+    await reconnectSettled;
   });
 });


### PR DESCRIPTION
## Problem

The Node.js WebSocket transport hard-coded `rejectUnauthorized: false` when constructing the underlying `ws` WebSocket. As a result, **every `wss://` connection accepted any server certificate** — self-signed, expired, or issued for a different hostname — and there was no builder option, constructor argument, or environment variable to turn verification back on.

Because the shipped auth providers attach credentials as an `Authorization` header on the WebSocket upgrade, a man-in-the-middle attacker on the network path could transparently terminate the TLS session, harvest Basic/Bearer credentials, and read or inject Ditto-Protocol frames for the lifetime of the connection.

- **Weakness:** CWE-295 (Improper Certificate Validation), secondary CWE-300
- **Affected:** `@eclipse-ditto/ditto-javascript-client-node`, WebSocket transport, all releases
- **Not affected:** Node HTTP transport (secure default), browser DOM client (delegates to the browser), Java client (uses a real `TrustManagerFactory`)

## Fix

- **Remove the implicit `rejectUnauthorized: false`** so connections inherit Node.js' secure defaults — certificate-chain **and** hostname validation.
- **Add an optional `TlsOptions` parameter** to `DittoNodeClient.newWebSocketClient(proxyOptions?, tlsOptions?)`, threaded through `NodeWebSocketBuilder` into `WebSocket.ClientOptions`. Callers can now supply custom trusted CAs / client certificates for mutual TLS, or an explicit, audited `{ rejectUnauthorized: false }` opt-out. This mirrors the Java client's `trustedCertificates(...)` capability. The opt-out is always explicit and per-client; the library never disables verification implicitly.
- **Reject the connection promise on the WebSocket `error` event** so an invalid certificate surfaces as a clear rejection instead of a promise that never settles.

```javascript
const fs = require('fs');

// Trust a corporate root / self-signed CA that is not in the system trust store:
DittoNodeClient.newWebSocketClient(undefined, { ca: fs.readFileSync('corp-root.pem') })
  .withTls()
  .withDomain('ditto.example.com')
  // ...
```

## Tests

- New regression test (`node-websocket.spec.ts`) spins up a self-signed, hostname-mismatched WSS server and asserts:
  - the connection is **rejected by default** and no `Authorization` header is leaked;
  - the explicit `{ rejectUnauthorized: false }` opt-out still connects.
- Full Node package suite: **30/30 pass**; `tsc` + barrel build clean; ESLint clean on all changed files.

## Notes

- `withTls()` behaviour is unchanged (it still only selects the `wss` scheme); TLS material is supplied at the `newWebSocketClient(...)` entry point, consistent with how `ProxyOptions` is already passed.
- Backport candidates per `SECURITY.md`: **3.9.x** and **3.8.x**.
