### PR TITLE
Fix JS buffered WebSocket poll before connect

### DIFF
--- a/javascript/lib/api/src/client/request-factory/resilience/websocket-resilience-handler-standard.ts
+++ b/javascript/lib/api/src/client/request-factory/resilience/websocket-resilience-handler-standard.ts
@@ -34,6 +34,10 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
   private readonly requestBuffer: ResilienceRequestBuffer;
   private readonly messageBuffer: ResilienceMessageBuffer;
   private webSocket: WebSocketImplementation | undefined;
+  private lastWebSocket: WebSocketImplementation | undefined;
+  private closeRequested = false;
+  private closeCode?: number;
+  private closeReason?: string;
 
   public constructor(webSocketBuilder: WebSocketImplementationBuilderHandler,
                      stateHandler: WebSocketStateHandler,
@@ -59,6 +63,7 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
     const jsonified = request.toJson();
     this.requestBuffer.addRequest(correlationId, jsonified);
     const webSocket = this.webSocket;
+    // A late response can mark the state connected while a replacement socket is still pending.
     if (this.stateHandler.isBuffering() || webSocket === undefined) {
       if (!this.stateHandler.isWorking()) {
         this.rejectRequest(correlationId, connectionLostError);
@@ -108,9 +113,15 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
   }
 
   public close(code?: number, reason?: string): void {
-    if (this.webSocket !== undefined) {
-      this.webSocket.close(code, reason);
-    }
+    this.closeRequested = true;
+    this.closeCode = code;
+    this.closeReason = reason;
+    const socket = this.webSocket ?? this.lastWebSocket;
+    this.webSocket = undefined;
+    this.stateHandler.disconnected();
+    this.rejectAllOngoing(connectionLostError);
+    // The previous implementation owns the reconnect loop even while its replacement is pending.
+    socket?.close(code, reason);
   }
 
   /**
@@ -118,13 +129,22 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
    * If the Promise gets rejected the reconnection process will be stopped and all further requests rejected.
    * After the Promise is resolved emptying of the buffer will be initiated. As long as there are requests left in the buffer new
    * requests will continue to be added to the buffer.
+   * Clears the current socket immediately so polling cannot write to a stale connection during reconnect.
+   * A socket arriving after close() is closed without flushing buffered work.
    *
    * @param promise - The promise for the new web socket
    */
   protected resolveWebSocket(promise: Promise<WebSocketImplementation>) {
+    if (this.webSocket !== undefined) {
+      this.lastWebSocket = this.webSocket;
+    }
     this.webSocket = undefined;
     promise
       .then(socket => {
+        if (this.closeRequested) {
+          socket.close(this.closeCode, this.closeReason);
+          return;
+        }
         this.webSocket = socket;
         this.checkBufferState();
         this.poll();
@@ -182,7 +202,8 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
 
   /**
    * Sends the next element of the request buffer and if there was such an element will do the same thing again in 500ms.
-   * Does nothing while the WebSocket is not yet connected so outstanding requests stay buffered.
+   * Does nothing while the WebSocket is not yet connected so outstanding requests stay buffered
+   * until resolveWebSocket restarts polling on open.
    */
   private poll(): void {
     const webSocket = this.webSocket;

--- a/javascript/lib/api/src/client/request-factory/resilience/websocket-resilience-handler-standard.ts
+++ b/javascript/lib/api/src/client/request-factory/resilience/websocket-resilience-handler-standard.ts
@@ -33,7 +33,7 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
 
   private readonly requestBuffer: ResilienceRequestBuffer;
   private readonly messageBuffer: ResilienceMessageBuffer;
-  private webSocket!: WebSocketImplementation;
+  private webSocket: WebSocketImplementation | undefined;
 
   public constructor(webSocketBuilder: WebSocketImplementationBuilderHandler,
                      stateHandler: WebSocketStateHandler,
@@ -58,19 +58,21 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
   sendRequest(correlationId: string, request: DittoProtocolEnvelope): void {
     const jsonified = request.toJson();
     this.requestBuffer.addRequest(correlationId, jsonified);
-    if (this.stateHandler.isBuffering()) {
+    const webSocket = this.webSocket;
+    if (this.stateHandler.isBuffering() || webSocket === undefined) {
       if (!this.stateHandler.isWorking()) {
         this.rejectRequest(correlationId, connectionLostError);
       } else {
         this.addToOutstandingBuffer(correlationId);
       }
     } else {
-      this.webSocket.executeCommand(jsonified);
+      webSocket.executeCommand(jsonified);
     }
   }
 
   send(message: string): Promise<void> {
-    if (!this.stateHandler.canSend()) {
+    const webSocket = this.webSocket;
+    if (!this.stateHandler.canSend() || webSocket === undefined) {
       if (!this.stateHandler.isWorking()) {
         return Promise.reject(connectionLostError);
       }
@@ -81,7 +83,7 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
       return this.messageBuffer.addMessage(message);
 
     }
-    this.webSocket.executeCommand(message);
+    webSocket.executeCommand(message);
     return Promise.resolve();
   }
 
@@ -106,7 +108,9 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
   }
 
   public close(code?: number, reason?: string): void {
-    this.webSocket.close(code, reason);
+    if (this.webSocket !== undefined) {
+      this.webSocket.close(code, reason);
+    }
   }
 
   /**
@@ -118,12 +122,13 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
    * @param promise - The promise for the new web socket
    */
   protected resolveWebSocket(promise: Promise<WebSocketImplementation>) {
+    this.webSocket = undefined;
     promise
       .then(socket => {
         this.webSocket = socket;
         this.checkBufferState();
         this.poll();
-        if (!this.messageBuffer.sendMessages(this.webSocket)) {
+        if (!this.messageBuffer.sendMessages(socket)) {
           throw Error('Messages could not be sent from Buffer');
         }
         if (this.requestBuffer.empty() && this.messageBuffer.empty()) {
@@ -177,9 +182,14 @@ export class StandardResilienceHandler extends AbstractResilienceHandler {
 
   /**
    * Sends the next element of the request buffer and if there was such an element will do the same thing again in 500ms.
+   * Does nothing while the WebSocket is not yet connected so outstanding requests stay buffered.
    */
   private poll(): void {
-    if (this.requestBuffer.sendNextOutstanding(this.webSocket)) {
+    const webSocket = this.webSocket;
+    if (webSocket === undefined) {
+      return;
+    }
+    if (this.requestBuffer.sendNextOutstanding(webSocket)) {
       setTimeout(() => this.poll(), 500);
     }
   }

--- a/javascript/lib/api/tests/client/websocket/websocket-resilience-handler-standard.spec.ts
+++ b/javascript/lib/api/tests/client/websocket/websocket-resilience-handler-standard.spec.ts
@@ -1,0 +1,91 @@
+/*!
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import { jest } from '@jest/globals';
+import { StandardResilienceHandler } from '../../../src/client/request-factory/resilience/websocket-resilience-handler-standard';
+import {
+  NoopWebSocketStateHandler,
+  RequestHandler,
+  WebSocketImplementation,
+  WebSocketImplementationBuilderHandler
+} from '../../../src/client/request-factory/resilience/websocket-resilience-interfaces';
+import { DefaultDittoProtocolEnvelope } from '../../../src/model/ditto-protocol';
+
+/**
+ * #158: addToOutstandingBuffer starts a 500ms poll before the connect Promise
+ * resolves. poll() must not call sendNextOutstanding with an uninitialized socket.
+ */
+describe('StandardResilienceHandler poll before connect', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not poll/send while the WebSocket is undefined and flushes after it opens', async () => {
+    const executeCommand = jest.fn();
+    const socket: WebSocketImplementation = {
+      executeCommand,
+      close: jest.fn()
+    };
+
+    let resolveSocket: (ws: WebSocketImplementation) => void = () => undefined;
+    const pending = new Promise<WebSocketImplementation>(resolve => {
+      resolveSocket = resolve;
+    });
+    const builder: WebSocketImplementationBuilderHandler = {
+      withHandler: () => pending
+    };
+    const requestHandler: RequestHandler = {
+      handleInput: jest.fn(),
+      handleMessage: jest.fn(),
+      handleError: jest.fn()
+    };
+
+    const handler = new StandardResilienceHandler(
+      builder,
+      new NoopWebSocketStateHandler(),
+      requestHandler,
+      10
+    );
+
+    const request = new DefaultDittoProtocolEnvelope(
+      'org.eclipse.ditto/thing/things/twin/commands/retrieve',
+      { 'correlation-id': 'corr-1' },
+      '/',
+      {}
+    );
+
+    expect(() => handler.sendRequest('corr-1', request)).not.toThrow();
+    expect(executeCommand).not.toHaveBeenCalled();
+
+    expect(() => {
+      jest.advanceTimersByTime(500);
+    }).not.toThrow();
+    expect(executeCommand).not.toHaveBeenCalled();
+
+    expect(() => {
+      jest.advanceTimersByTime(1000);
+    }).not.toThrow();
+    expect(executeCommand).not.toHaveBeenCalled();
+
+    resolveSocket(socket);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(String(executeCommand.mock.calls[0][0])).toContain('corr-1');
+  });
+});

--- a/javascript/lib/api/tests/client/websocket/websocket-resilience-handler-standard.spec.ts
+++ b/javascript/lib/api/tests/client/websocket/websocket-resilience-handler-standard.spec.ts
@@ -82,10 +82,80 @@ describe('StandardResilienceHandler poll before connect', () => {
     expect(executeCommand).not.toHaveBeenCalled();
 
     resolveSocket(socket);
-    await Promise.resolve();
-    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(executeCommand).toHaveBeenCalledTimes(1);
     expect(String(executeCommand.mock.calls[0][0])).toContain('corr-1');
+  });
+
+  function setup() {
+    let resolveSocket!: (socket: WebSocketImplementation) => void;
+    const pending = new Promise<WebSocketImplementation>(resolve => { resolveSocket = resolve; });
+    const state = new NoopWebSocketStateHandler();
+    const connected = jest.spyOn(state, 'connected');
+    const handler = new StandardResilienceHandler(
+      { withHandler: () => pending }, state,
+      { handleInput: jest.fn(), handleMessage: jest.fn(), handleError: jest.fn() }, 10
+    );
+    const socket = { executeCommand: jest.fn(), close: jest.fn() };
+    return { handler, socket, resolveSocket, connected };
+  }
+
+  it('flushes a message buffered before the initial connection opens', async () => {
+    const { handler, socket, resolveSocket } = setup();
+    const sent = handler.send('buffered message');
+    expect(socket.executeCommand).not.toHaveBeenCalled();
+    resolveSocket(socket);
+    await sent;
+    expect(socket.executeCommand).toHaveBeenCalledWith('buffered message');
+  });
+
+  it('closes a socket arriving after close without sending buffered messages', async () => {
+    const { handler, socket, resolveSocket, connected } = setup();
+    const sent = handler.send('do not send');
+    const rejected = expect(sent).rejects.toMatchObject({ error: 'connection.lost' });
+    handler.close(1000, 'shutdown');
+    await rejected;
+    resolveSocket(socket);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(socket.close).toHaveBeenCalledWith(1000, 'shutdown');
+    expect(socket.executeCommand).not.toHaveBeenCalled();
+    expect(connected).not.toHaveBeenCalled();
+    await expect(handler.send('after close')).rejects.toMatchObject({ error: 'connection.lost' });
+  });
+
+  it('cancels the underlying reconnect loop and closes a late replacement', async () => {
+    const { handler, socket, resolveSocket, connected } = setup();
+    resolveSocket(socket);
+    await jest.advanceTimersByTimeAsync(0);
+    connected.mockClear();
+    let reconnect!: (socket: WebSocketImplementation) => void;
+    handler.handleClose(new Promise(resolve => { reconnect = resolve; }));
+    handler.close(1000, 'shutdown');
+    expect(socket.close).toHaveBeenCalledWith(1000, 'shutdown');
+    const replacement = { executeCommand: jest.fn(), close: jest.fn() };
+    reconnect(replacement);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(replacement.close).toHaveBeenCalledWith(1000, 'shutdown');
+    expect(connected).not.toHaveBeenCalled();
+    expect(replacement.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('keeps reconnect requests off the stale socket until the replacement opens', async () => {
+    const { handler, socket, resolveSocket } = setup();
+    resolveSocket(socket);
+    await jest.advanceTimersByTimeAsync(0);
+    let reconnect!: (socket: WebSocketImplementation) => void;
+    handler.handleClose(new Promise(resolve => { reconnect = resolve; }));
+    const request = new DefaultDittoProtocolEnvelope(
+      'org.eclipse.ditto/thing/things/twin/commands/retrieve', { 'correlation-id': 'reconnect' }, '/', {}
+    );
+    handler.sendRequest('reconnect', request);
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(socket.executeCommand).not.toHaveBeenCalled();
+    const replacement = { executeCommand: jest.fn(), close: jest.fn() };
+    reconnect(replacement);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(replacement.executeCommand).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Summary
The buffered JavaScript WebSocket client started a 500ms `#poll()` as soon as a request was queued. `#poll()` did not check that `this.webSocket` existed, so a connect slower than 500ms called `sendNextOutstanding` with an uninitialized socket and crashed on `executeCommand`.

`poll()` now returns until the WebSocket exists (the connect Promise resolves on open). Outstanding requests stay in the buffer and are flushed from `resolveWebSocket`. Direct send paths buffer as well when the socket is not yet assigned.

### Validation
- Reproduced the crash: unit test failed with `TypeError: Cannot read properties of undefined (reading 'executeCommand')` before the guard.
- `npx jest tests/client/websocket/websocket-resilience-handler-standard.spec.ts tests/client/websocket/buffer.websocket.spec.ts tests/client/websocket/bufferless.websocket.spec.ts` — pass
- `npm test --workspace=@eclipse-ditto/ditto-javascript-client-api` — 376 passed
- `cd javascript && npm run lint && npm test` — lint clean; api 376, dom 13, node 31 passed

Fixes #158

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.